### PR TITLE
Add feed templates

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: python3 -m pip install krystal
     - name: Build
-      run: krystal --build
+      run: krystal --build --base-url "https://krystalgamer.github.io/"
     - name: Put in gh-pages
       run: |
         touch build/.nojekyll

--- a/templates/feed.xml
+++ b/templates/feed.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <id>{{ url_for('serve_feed', _external=True) }}</id>
+    <title>krystalgamer's Blog</title>
+    <link rel="alternate" href="{{ url_for('serve_main', _external=True) }}" />
+    <link rel="self" href="{{ url_for('serve_feed', _external=True) }}" />
+    <updated>{{ now.isoformat('T', 'seconds') }}Z</updated>
+    <author><name>krystalgamer</name></author>
+
+    {% for entry in entries %}
+    <entry>
+        <id>{{ url_for('serve_post', post_id=entry.id, _external=True) }}</id>
+        <title>{{ entry.title }}</title>
+        <published>{{ entry.timestamp.isoformat('T', 'seconds') }}Z</published>
+        <updated>{{ entry.modified_timestamp.isoformat('T', 'seconds') }}Z</updated>
+        <link rel="alternate" href="{{ url_for('serve_post', post_id=entry.id, _external=True) }}" />
+    </entry>
+    {% endfor %}
+</feed>

--- a/templates/skeleton.html
+++ b/templates/skeleton.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/pure-min.css" integrity="sha384-Uu6IeWbM+gzNVXJcM9XV3SohHtmWE+3VGi496jvgX1jyvDTXfdK+rfZc8C1Aehk5" crossorigin="anonymous">
 		<link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" >
 		<meta name="viewport" content="width=device-width, initial-scale=1">
-		
+		<link rel="alternate" type="application/atom+xml" href="{{ url_for('serve_feed') }}">
 
 		{% block embed %}
 			<meta property="og:title" content="{{ self.title() }}" />


### PR DESCRIPTION
Please see https://github.com/krystalgamer/krystal/pull/1 first. This contains the necessary templates and configuration changes to generate and autolink an Atom feed.

As with the other PR, this has a caveat, notably that to easily force ISO timestamp compatibility, this bodges all timestamps to be interpreted as UTC, even though they're likely not (especially the `updated` one.) Still, this isn't likely to cause problems, as long as the timestamps are monotonous.

The generated feed validates with the [W3C feed validator](https://validator.w3.org/feed/). The interop warnings shouldn't be a problem for most usage.